### PR TITLE
Fix: resolve PHP 8.4 implicit-nullable deprecation

### DIFF
--- a/src/Platform.php
+++ b/src/Platform.php
@@ -123,13 +123,13 @@ class Platform
      *
      * @return T|false The matching entry, or false if no match is found
      */
-    public static function findBestMatch(array $platformEntries, array $currentPlatform = null): mixed
+    public static function findBestMatch(array $platformEntries, ?array $currentPlatform = null): mixed
     {
         $currentPlatform = $currentPlatform ?? self::current();
 
         $matchingPlatforms = array_filter(
             array_keys($platformEntries),
-            fn ($platform) => self::matches($platform, $currentPlatform)
+            fn($platform) => self::matches($platform, $currentPlatform)
         );
 
         $prioritizedMatches = self::prioritizePlatformMatches($matchingPlatforms);


### PR DESCRIPTION
Fixes PHP 8.4 implicit-nullable deprecation by making the affected parameter explicitly nullable. No behavior change.