### PR TITLE
Feat: replace platform-urls with artifacts and add template variable support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,8 @@ jobs:
     name: Tests PHP${{ matrix.php }} - ${{ matrix.os }}
 
     steps:
-
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -32,8 +25,8 @@ jobs:
           extensions: dom, mbstring, zip
           coverage: none
 
-      - name: Install Composer dependencies
-        run: composer update --no-interaction --prefer-dist
+      - name: Install dependencies
+        uses: ramsey/composer-install@v4
 
       - name: Run Tests
         run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
 
     name: Tests PHP${{ matrix.php }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,8 @@ For the example above, the generated config added to `composer.json` would look 
 {
   "extra": {
     "artifacts": {
-      "urls": {
-        "linux-x86_64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-linux-x86_64.tar.gz",
-        "darwin-arm64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-darwin-arm64.tar.gz"
-      }
+      "linux-x86_64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-linux-x86_64.tar.gz",
+      "darwin-arm64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-darwin-arm64.tar.gz"
     }
   }
 }
@@ -124,11 +122,16 @@ better than nothing).
 
 ### Application Overrides (Variables)
 
+`extra.artifacts` supports two formats:
+
+1. **Simple format** (no variables): provide platform URLs directly under `artifacts`.
+2. **Extended format** (with variables): provide `artifacts.urls` and optional `artifacts.vars`.
+
 Platform packages can optionally define placeholder variables that are substituted into the selected URL at install time.
 `{version}` is built in and always available. You can also use custom placeholders like `{cuda}` and set defaults in the
 platform package, then override them in the consuming application (root project).
 
-**Platform package (defaults):**
+**Platform package (extended format with defaults):**
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Composer Platform Package Installer
 
-The Composer Platform Package Installer is a powerful Composer plugin that provides fine-grained control over package
-distribution across different platforms and architectures. Unlike traditional Composer package management, this plugin
-allows you to:
+The Composer Platform Package Installer is a powerful plugin for platform-aware distribution URL resolution.
 
-- Exclude specific folders and files for different platforms
-- Generate platform-specific distribution URLs
-- Customize package installation for various operating systems and architectures
+The core behavior is simple:
+
+- Your package declares platform-specific artifact URLs or URL templates in `composer.json`
+- At install time, the plugin picks the best URL for the current OS/architecture
+- It resolves placeholders (built-in `{version}` plus optional custom variables)
+- It tells Composer to download and install the package from that resolved URL
 
 ## Requirements
 
-- PHP 8.1 or higher
-- Composer 2.0 or higher
+- PHP 8.1+
+- Composer 2+
 
 ## Installation
 
@@ -21,237 +22,142 @@ Install the plugin using Composer:
 composer require codewithkyrian/platform-package-installer
 ```
 
-## Usage Guide
-
-### Step 1: Package Configuration
-
-Change your package type to `platform-package` in `composer.json`:
+Then change your package type to `platform-package` in `composer.json`:
 
 ```json
 {
-  "name": "org/library",
+  "name": "org/your-platform-package",
   "type": "platform-package",
   "require": {
-    "codewithkyrian/platform-package-installer": "^1.0"
+    "codewithkyrian/platform-package-installer": "^2.0"
   }
 }
 ```
 
-### Step 2: Create Platforms Configuration
+## Core Configuration
 
-Create a `platforms.yml` file in the root of your project and list the platforms you want to support:
+All core behavior is configured in `composer.json` under `extra.artifacts`.
 
-```yaml
-linux-x86_64:
-linux-arm64:
-darwin-arm64:
-darwin-x86_64:
-windows-32:
-windows-64:
-```
+### Format A: Simple (no custom variables)
 
-You can also specify exclusion rules for each platform (this will come in handy later when generating distribution
-archives).
+Use this when:
 
-```yaml
-linux-x86_64:
-  exclude:
-    - libs/linux-arm64
-    - libs/darwin-*
-    - libs/windows-*
-    - "*.exe"
-    - "*.dylib"
-    - "**/*.windows.*"
-
-darwin-x86_64:
-  exclude:
-    - libs/darwin-arm64
-    - libs/windows-*
-    - libs/linux-*
-    - "*.exe"
-    - "*.so"
-    - "**/*.linux.*"
-
-# Add configurations for other platforms similarly
-```
-
-**Exclusion Rule Patterns:**
-
-- Use standard glob patterns to specify exclusions
-- `*` matches any number of characters
-- `**` matches nested directories
-- Platform-specific libraries, binaries, and incompatible files can be easily filtered
-
-### Step 3: Generate Distribution URLs
-
-Use the `platform:generate-urls` command to create platform-specific download URLs and add them to `composer.json`. This
-is very important because Composer will use these URLs to download the appropriate platform-specific package.
-
-```bash
-composer platform:generate-urls --dist-type=github --repo-path=vendor/repo
-
-// Or using a custom template
-
-composer platform:generate-urls --dist-type=https://cdn.example.com/vendor/repo/release-{version}-{platform}.{ext}
-```
-
-**Command Options**
-
-- `--platforms-file`: Path to the platforms.yml file (optional, defaults to `platforms.yml`)
-- `--dist-type`: Distribution source type (`github`, `gitlab`, `huggingface`, or a custom URL template)
-- `--repo-path`: Repository path (optional when using a custom URL template)
-- `--extension`: File extension (optional. Uses .zip for Windows and .tar.gz for others)
-
-For the example above, the generated config added to `composer.json` would look like:
+- you are using direct artifact URLs with no placeholders, or
+- `{version}` is the only placeholder you need.
 
 ```json
 {
   "extra": {
     "artifacts": {
-      "linux-x86_64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-linux-x86_64.tar.gz",
-      "darwin-arm64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-darwin-arm64.tar.gz"
+      "darwin-arm64": "https://cdn.example.com/pkg/{version}/darwin-arm64.zip",
+      "linux-x86_64": "https://cdn.example.com/pkg/{version}/linux-x86_64.tar.gz",
+      "all": "https://cdn.example.com/pkg/{version}/universal.zip"
     }
   }
 }
 ```
 
-Now the next time someone installs your package, Composer will use the generated URLs to download the appropriate
-platform-specific package. The good thing is that if for any reason the URLs are wrong or not working, Composer
-falls back to downloading the original source (which means more things to download and slower installation but hey, it's
-better than nothing).
+### Format B: Extended (custom variables + defaults)
 
-### Application Overrides (Variables)
-
-`extra.artifacts` supports two formats:
-
-1. **Simple format** (no variables): provide platform URLs directly under `artifacts`.
-2. **Extended format** (with variables): provide `artifacts.urls` and optional `artifacts.vars`.
-
-Platform packages can optionally define placeholder variables that are substituted into the selected URL at install time.
-`{version}` is built in and always available. You can also use custom placeholders like `{cuda}` and set defaults in the
-platform package, then override them in the consuming application (root project).
-
-**Platform package (extended format with defaults):**
+Use this when templates include additional placeholders beyond `{version}`.
 
 ```json
 {
   "extra": {
     "artifacts": {
-      "vars": {
-        "cuda": "12"
-      },
       "urls": {
-        "darwin-arm64": "https://cdn.example.com/onyx/{version}/cuda-{cuda}/dist-darwin-arm64.tar.gz"
+        "darwin-arm64": "https://cdn.example.com/pkg/{version}/variant-{runtime}/darwin-arm64.zip",
+        "linux-x86_64": "https://cdn.example.com/pkg/{version}/variant-{runtime}/linux-x86_64.tar.gz"
+      },
+      "vars": {
+        "runtime": "gpu"
       }
     }
   }
 }
 ```
 
-**Application (overrides by package name):**
+## Application-Level Variable Overrides
+
+Consumers of your platform package can override variables from their root project:
 
 ```json
 {
   "extra": {
     "platform-packages": {
-      "org/onyx-runtime": {
-        "cuda": "13"
+      "org/your-platform-package": {
+        "runtime": "cpu"
       }
     }
   }
 }
 ```
 
-## Platform Identifiers
+Variable precedence:
 
-Platform Identifiers are used to specify the platform-specific package URL. Platform identifiers can be:
+1. Root app override (`extra.platform-packages.<package-name>`)
+2. Package default (`extra.artifacts.vars`)
+3. Built-in `{version}` (always provided by plugin)
 
-- **Base platform names**: The supported base platform names are `linux`, `darwin`, `windows` and `raspberrypi`. This
-  means that the distribution archive can be used on any architecture of these platforms.
-- **Specific architectures**: You can be more specific by specifying the architecture as well. The identifier is formed
-  by joining the platform identifier with the architecture identifier (`-`), e.g. `darwin-arm64`, `darwin-x86_64`,
-  `windows-32`, `windows-64`, `linux-aarch64`, etc.
-- **Universal**: Use `all` to cover every platform
+## Placeholder Behavior
 
-## Distribution Archives
+- `{version}` is built in and always available
+- Any `{name}` placeholder can be used
+- Unresolved placeholders cause artifact URL resolution to fail for that package
+- On failure, Composer falls back to the package's original `dist` configuration
 
-For regular packages, GitHub and GitLab provide an automatic distribution archive (tarball or zip) for each release.
-Using this package however, means you can no longer rely on those automatic distribution archives.
+## Platform Matching
 
-The `composer platform:generate-urls` only generates urls for the platforms specified in the `platforms.yml` file using a
-template, but you still need to manually generate the archive for each platform and make them available at those
-locations.
+The plugin matches the current machine against keys in `artifacts`:
 
-### GitHub
+- OS-only keys: `linux`, `darwin`, `windows`, `raspberrypi`
+- OS + architecture keys: `darwin-arm64`, `linux-x86_64`, `windows-32`, `windows-64`, etc.
+- `all` as final fallback
 
-The generated GitHub distribution archive is available at the following URL:
+More specific matches are preferred over generic ones.
 
-```
-https://github.com/vendor/package/releases/download/{version}/dist-{platform}.{ext}
-```
+## Optional Helper: Generate URLs Command
 
-`{platform}` and `{ext}` will be replaced with the platform identifier and the file extension when generating the URL
-while `{version}` will be replaced with the package version at installation time.
+`platform:generate-urls` is a helper to generate artifact URL entries from a template.
 
-The package provides a convenient example [GitHub Actions workflow](workflows/github-release.yml) that uses the
-`platforms.yml` file to generate the distribution archives every release and upload them as release assets. Feel free to
-modify the workflow to suit your needs.
-
-### GitLab
-
-The GitLab distribution archive is available at the following URL:
-
-```
-https://gitlab.com/vendor/package/-/releases/{version}/downloads/dist-{platform}.{ext}
+```bash
+composer platform:generate-urls --dist-type=github --repo-path=vendor/repo --platforms=linux-x86_64 --platforms=darwin-arm64
 ```
 
-At the moment, there's no example workflow for GitLab. Contributions are welcome for a similar workflow.
+You can also provide platforms as a comma-separated list:
 
-> Always test the workflow thoroughly to ensure it generates the correct distribution archives for each platform.
-
-## Runtime Utility
-
-The package provides a powerful utility method `findBestMatch()` to easily handle platform-specific resources at
-runtime. It finds the most appropriate match for the current platform from a given set of platform-specific entries.
-
-```php
-use Codewithkyrian\PlatformPackageInstaller\Platform;
-
-// Example with directory paths
-$libraryPaths = [
-    'linux-x86_64' => '/path/to/linux/x86_64/libs',
-    'darwin-arm64' => '/path/to/mac/arm64/libs',
-    'windows-x86_64' => '/path/to/windows/x86_64/libs'
-];
-
-$bestLibraryPath = Platform::findBestMatch($libraryPaths);
-
-// Example with configuration arrays
-$platformConfigs = [
-    'linux-x86_64' => [
-        'library_path' => '/path/to/linux/libs',
-        'additional_config' => ['key' => 'value']
-    ],
-    'darwin-arm64' => [
-        'library_path' => '/path/to/mac/libs',
-        'additional_config' => ['key' => 'another_value']
-    ]
-];
-
-$currentPlatformConfig = Platform::findBestMatch($platformConfigs);
+```bash
+composer platform:generate-urls --dist-type=github --repo-path=vendor/repo --platforms=linux-x86_64,darwin-arm64,windows-x86_64
 ```
 
-## Tests
+Or with a custom URL template:
 
-The `tests` folder contains a suite of tests that verify the behavior of the plugin. To run the tests, you need
-to install the development dependencies using the `composer install --dev` command. Then, run the tests using either
-the `composer test` command or the `./vendor/bin/pest` command.
+```bash
+composer platform:generate-urls --dist-type=https://cdn.example.com/vendor/repo/release-{version}-{platform}.{ext} --platforms=linux-x86_64,darwin-arm64
+```
+
+Command options:
+
+- `--platforms` platform identifiers (repeat the flag or use comma-separated values)
+- `--dist-type` `github`, `gitlab`, `huggingface`, or custom template
+- `--repo-path` repository path for built-in templates
+- `--extension` force archive extension
+
+The command writes generated URLs into `extra.artifacts`.
+
+## Testing
+
+Run tests with:
+
+```bash
+composer test
+```
+
+The test suite includes:
+
+- unit tests for matching, templating, and generation logic
+- integration tests that run real `composer install` flows
 
 ## License
 
-This project is licensed under the MIT License. See
-the [LICENSE](https://github.com/codewithkyrian/platform-package-installer/blob/main/LICENSE) file for more information.
-
-## Contributing
-
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+MIT. See [LICENSE](https://github.com/codewithkyrian/platform-package-installer/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ For the example above, the generated config added to `composer.json` would look 
 ```json
 {
   "extra": {
-    "platform-urls": {
-      "linux-x86_64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-linux-x86_64.tar.gz",
-      "darwin-arm64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-darwin-arm64.tar.gz"
+    "artifacts": {
+      "urls": {
+        "linux-x86_64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-linux-x86_64.tar.gz",
+        "darwin-arm64": "https://github.com/Codewithkyrian/example/releases/download/{version}/dist-darwin-arm64.tar.gz"
+      }
     }
   }
 }
@@ -119,6 +121,43 @@ Now the next time someone installs your package, Composer will use the generated
 platform-specific package. The good thing is that if for any reason the URLs are wrong or not working, Composer
 falls back to downloading the original source (which means more things to download and slower installation but hey, it's
 better than nothing).
+
+### Application Overrides (Variables)
+
+Platform packages can optionally define placeholder variables that are substituted into the selected URL at install time.
+`{version}` is built in and always available. You can also use custom placeholders like `{cuda}` and set defaults in the
+platform package, then override them in the consuming application (root project).
+
+**Platform package (defaults):**
+
+```json
+{
+  "extra": {
+    "artifacts": {
+      "vars": {
+        "cuda": "12"
+      },
+      "urls": {
+        "darwin-arm64": "https://cdn.example.com/onyx/{version}/cuda-{cuda}/dist-darwin-arm64.tar.gz"
+      }
+    }
+  }
+}
+```
+
+**Application (overrides by package name):**
+
+```json
+{
+  "extra": {
+    "platform-packages": {
+      "org/onyx-runtime": {
+        "cuda": "13"
+      }
+    }
+  }
+}
+```
 
 ## Platform Identifiers
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "codewithkyrian/platform-package-installer",
-  "description": "A Composer plugin that provides fine-grained control over platform-specific package distribution for PHP projects",
+  "description": "A Composer plugin for platform-aware distribution URL resolution",
   "type": "composer-plugin",
   "license": "MIT",
   "autoload": {
@@ -22,8 +22,7 @@
   "require": {
     "php": "^8.1",
     "composer-plugin-api": "^1.1 || ^2.0",
-    "composer-runtime-api": "*",
-    "symfony/yaml": "^6.4 || ^7.2 || ^8.0"
+    "composer-runtime-api": "*"
   },
   "require-dev": {
     "composer/composer": "~1.0 || ~2.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "test": "vendor/bin/pest",
-    "test:coverage": "XDEBUG_MODE=coverage ./vendor/bin/pest --coverage"
+    "test:coverage": "./vendor/bin/pest --coverage"
   },
   "extra": {
     "class": "Codewithkyrian\\PlatformPackageInstaller\\Plugin",

--- a/src/ArtifactUrlResolver.php
+++ b/src/ArtifactUrlResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codewithkyrian\PlatformPackageInstaller;
+
+final class ArtifactUrlResolver
+{
+    /**
+     * @param array<string, mixed> $defaultVars
+     * @param array<string, mixed> $overrideVars
+     *
+     * @return array<string, string>
+     */
+    public function mergeVars(array $defaultVars, array $overrideVars, string $version): array
+    {
+        $vars = array_merge($defaultVars, $overrideVars);
+        $vars['version'] = $version;
+
+        $out = [];
+        foreach ($vars as $key => $value) {
+            if (!is_string($key) || $key === '') {
+                continue;
+            }
+
+            if (is_scalar($value) || $value === null) {
+                $out[$key] = (string) $value;
+                continue;
+            }
+
+            $encoded = json_encode($value);
+            $out[$key] = $encoded === false ? '' : $encoded;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Apply `{name}` placeholders using provided vars. Unknown placeholders are left intact.
+     *
+     * @param array<string, string> $vars
+     */
+    public function applyTemplate(string $template, array $vars): string
+    {
+        return (string) preg_replace_callback('/\{([a-zA-Z0-9_-]+)\}/', function (array $m) use ($vars) {
+            $key = $m[1] ?? '';
+            if ($key === '' || !array_key_exists($key, $vars)) {
+                return $m[0];
+            }
+
+            return $vars[$key];
+        }, $template);
+    }
+
+    /**
+     * @return list<string> placeholder keys still present in the value
+     */
+    public function unresolvedPlaceholders(string $value): array
+    {
+        if (!preg_match_all('/\{([a-zA-Z0-9_-]+)\}/', $value, $matches)) {
+            return [];
+        }
+
+        /** @var list<string> $keys */
+        $keys = array_values(array_unique($matches[1] ?? []));
+        sort($keys);
+        return $keys;
+    }
+}

--- a/src/GenerateUrlCommand.php
+++ b/src/GenerateUrlCommand.php
@@ -10,7 +10,6 @@ use Composer\Factory;
 use Composer\Json\JsonFile;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Yaml\Yaml;
 
 class GenerateUrlCommand extends BaseCommand
 {
@@ -23,7 +22,7 @@ class GenerateUrlCommand extends BaseCommand
     protected function configure(): void
     {
         $this->setName('platform:generate-urls')
-            ->setDescription('Generate platform-specific URLs from a platforms.yml file')
+            ->setDescription('Generate platform-specific URLs from a platform list')
             ->addOption(
                 'dist-type',
                 'dist',
@@ -31,10 +30,10 @@ class GenerateUrlCommand extends BaseCommand
                 'Distribution type (github, gitlab, huggingface, or custom URL template)'
             )
             ->addOption(
-                'platforms-file',
+                'platforms',
                 'p',
-                InputOption::VALUE_OPTIONAL,
-                'Path to platforms.yml file'
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Platform identifiers (repeat option or use comma-separated values)'
             )
             ->addOption(
                 'repo-path',
@@ -52,21 +51,21 @@ class GenerateUrlCommand extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $platformsFile = $input->getOption('platforms-file');
+        /** @var array<int, string> $platformOptions */
+        $platformOptions = $input->getOption('platforms');
         $distType = $input->getOption('dist-type');
         $repoPath = $input->getOption('repo-path');
         $extensionOverride = $input->getOption('extension');
 
-        $platformsFile ??= dirname(Factory::getComposerFile()). DIRECTORY_SEPARATOR.'platforms.yml';
+        $platforms = $this->parsePlatforms($platformOptions);
 
-        if (!file_exists($platformsFile)) {
-            $output->writeln("<error>Platforms file not found: $platformsFile</error>");
+        if ($platforms === []) {
+            $output->writeln('<error>No platforms provided. Use --platforms to define at least one platform.</error>');
             return self::FAILURE;
         }
 
-        $platformsData = Yaml::parseFile($platformsFile);
         $urlTemplate = $this->resolveUrlTemplate($distType, $repoPath);
-        $platformUrls = $this->generatePlatformUrls($platformsData, $urlTemplate, $extensionOverride);
+        $platformUrls = $this->generatePlatformUrls($platforms, $urlTemplate, $extensionOverride);
 
         $this->updateComposerJson($platformUrls, $output);
 
@@ -87,16 +86,16 @@ class GenerateUrlCommand extends BaseCommand
         return $distType;
     }
 
-    private function generatePlatformUrls(
-        ?array  $platformsData,
-        string  $urlTemplate,
-        ?string $extensionOverride = null
-    ): array
+    /**
+     * @param array<int, string> $platforms
+     *
+     * @return array<string, string>
+     */
+    private function generatePlatformUrls(array $platforms, string $urlTemplate, ?string $extensionOverride = null): array
     {
         $platformUrls = [];
-        $platformsData ??= [];
 
-        foreach ($platformsData as $platform => $platformConfig) {
+        foreach ($platforms as $platform) {
             $ext = $extensionOverride ?? (str_starts_with(strtolower($platform), 'windows') ? 'zip' : 'tar.gz');
             $ext = ltrim($ext, '.');
 
@@ -106,6 +105,28 @@ class GenerateUrlCommand extends BaseCommand
         }
 
         return $platformUrls;
+    }
+
+    /**
+     * @param array<int, string> $platformOptions
+     *
+     * @return array<int, string>
+     */
+    private function parsePlatforms(array $platformOptions): array
+    {
+        $platforms = [];
+        foreach ($platformOptions as $entry) {
+            foreach (explode(',', $entry) as $platform) {
+                $platform = trim($platform);
+                if ($platform === '') {
+                    continue;
+                }
+
+                $platforms[] = $platform;
+            }
+        }
+
+        return array_values(array_unique($platforms));
     }
 
     private function updateComposerJson(array $platformUrls, OutputInterface $output): void

--- a/src/GenerateUrlCommand.php
+++ b/src/GenerateUrlCommand.php
@@ -115,7 +115,8 @@ class GenerateUrlCommand extends BaseCommand
         $composerJson = $jsonFile->read();
 
         $composerJson['extra'] = $composerJson['extra'] ?? [];
-        $composerJson['extra']['platform-urls'] = $platformUrls;
+        $composerJson['extra']['artifacts'] = $composerJson['extra']['artifacts'] ?? [];
+        $composerJson['extra']['artifacts']['urls'] = $platformUrls;
 
         $jsonFile->write($composerJson);
 

--- a/src/GenerateUrlCommand.php
+++ b/src/GenerateUrlCommand.php
@@ -115,8 +115,15 @@ class GenerateUrlCommand extends BaseCommand
         $composerJson = $jsonFile->read();
 
         $composerJson['extra'] = $composerJson['extra'] ?? [];
-        $composerJson['extra']['artifacts'] = $composerJson['extra']['artifacts'] ?? [];
-        $composerJson['extra']['artifacts']['urls'] = $platformUrls;
+        $existingArtifacts = $composerJson['extra']['artifacts'] ?? null;
+
+        if (is_array($existingArtifacts) && (array_key_exists('urls', $existingArtifacts) || array_key_exists('vars', $existingArtifacts))) {
+            $existingArtifacts['urls'] = $platformUrls;
+            $composerJson['extra']['artifacts'] = $existingArtifacts;
+        } else {
+            // Prefer the simple artifacts format when no vars are in use.
+            $composerJson['extra']['artifacts'] = $platformUrls;
+        }
 
         $jsonFile->write($composerJson);
 

--- a/src/PlatformInstaller.php
+++ b/src/PlatformInstaller.php
@@ -12,9 +12,12 @@ use React\Promise\PromiseInterface;
 
 class PlatformInstaller extends LibraryInstaller
 {
+    private ArtifactUrlResolver $artifactUrlResolver;
+
     public function __construct(IOInterface $io, PartialComposer $composer)
     {
         parent::__construct($io, $composer, "platform-package");
+        $this->artifactUrlResolver = new ArtifactUrlResolver();
     }
 
     public function download(PackageInterface $package, ?PackageInterface $prevPackage = null): ?PromiseInterface
@@ -29,16 +32,40 @@ class PlatformInstaller extends LibraryInstaller
 
     private function resolveDistUrl(PackageInterface $package): string|false
     {
-        $platformUrls = $package->getExtra()['platform-urls'] ?? [];
-        $platformUrls = $this->validatePlatformUrls($package, $platformUrls);
+        $artifacts = $package->getExtra()['artifacts'] ?? [];
+        if (!is_array($artifacts)) {
+            $this->io->writeError("{$package->getName()}: Invalid extra.artifacts config (expected object)");
+            return false;
+        }
 
-        if ($matchingUrl = Platform::findBestMatch($platformUrls)) {
-            // Check if the URL exists
-            if ($this->urlExists($matchingUrl)) {
-                return $matchingUrl;
+        $urls = $artifacts['urls'] ?? [];
+        if (!is_array($urls)) {
+            $this->io->writeError("{$package->getName()}: Invalid extra.artifacts.urls config (expected object)");
+            return false;
+        }
+
+        $validatedUrls = $this->validateArtifactUrls($package, $urls);
+        if ($matchingTemplate = Platform::findBestMatch($validatedUrls)) {
+            $vars = $this->resolveTemplateVars($package, $artifacts);
+            $resolvedUrl = $this->artifactUrlResolver->applyTemplate($matchingTemplate, $vars);
+
+            $unresolved = $this->artifactUrlResolver->unresolvedPlaceholders($resolvedUrl);
+            if ($unresolved !== []) {
+                $missing = implode(', ', array_map(fn($k) => '{'.$k.'}', $unresolved));
+                $this->io->writeError("{$package->getName()}: Unresolved URL placeholders: {$missing}");
+                return false;
             }
 
-            $this->io->writeError("{$package->getName()}: URL found for current platform but it doesn't exist: $matchingUrl");
+            if (!filter_var($resolvedUrl, FILTER_VALIDATE_URL)) {
+                $this->io->writeError("{$package->getName()}: Invalid resolved URL: $resolvedUrl");
+                return false;
+            }
+
+            if ($this->urlExists($resolvedUrl)) {
+                return $resolvedUrl;
+            }
+
+            $this->io->writeError("{$package->getName()}: URL found for current platform but it doesn't exist: $resolvedUrl");
             return false;
         }
 
@@ -66,27 +93,53 @@ class PlatformInstaller extends LibraryInstaller
 
     /**
      * @param PackageInterface $package
-     * @param array<string, string> $platformUrls
+     * @param array<string, mixed> $platformUrls
      *
      * @return array<string, string>
      */
-    private function validatePlatformUrls(PackageInterface $package, array $platformUrls): array
+    private function validateArtifactUrls(PackageInterface $package, array $platformUrls): array
     {
         $validatedPlatforms = [];
         foreach ($platformUrls as $platform => $url) {
-            assert(is_string($url), 'Platform URL must be a string');
-
-            $processedUrl = str_replace('{version}', $package->getPrettyVersion(), $url);
-
-            if (!filter_var($processedUrl, FILTER_VALIDATE_URL)) {
-                $this->io->writeError("{$package->getName()}: Invalid URL : $processedUrl. Skipping...");
+            if (!is_string($platform) || $platform === '') {
                 continue;
             }
 
-            $validatedPlatforms[strtolower($platform)] = $processedUrl;
+            if (!is_string($url) || $url === '') {
+                $this->io->writeError("{$package->getName()}: Invalid artifact URL for platform '$platform' (expected non-empty string). Skipping...");
+                continue;
+            }
+
+            $validatedPlatforms[strtolower($platform)] = $url;
         }
 
         return $validatedPlatforms;
+    }
+
+    /**
+     * @param array<string, mixed> $artifacts
+     *
+     * @return array<string, string>
+     */
+    private function resolveTemplateVars(PackageInterface $package, array $artifacts): array
+    {
+        $defaultVars = $artifacts['vars'] ?? [];
+        if (!is_array($defaultVars)) {
+            $defaultVars = [];
+        }
+
+        $rootExtra = $this->composer->getPackage()->getExtra();
+        $platformPackages = $rootExtra['platform-packages'] ?? [];
+        if (!is_array($platformPackages)) {
+            $platformPackages = [];
+        }
+
+        $overrideVars = $platformPackages[$package->getName()] ?? [];
+        if (!is_array($overrideVars)) {
+            $overrideVars = [];
+        }
+
+        return $this->artifactUrlResolver->mergeVars($defaultVars, $overrideVars, $package->getPrettyVersion());
     }
 
     private function inferArchiveType(string $url): string

--- a/src/PlatformInstaller.php
+++ b/src/PlatformInstaller.php
@@ -38,15 +38,14 @@ class PlatformInstaller extends LibraryInstaller
             return false;
         }
 
-        $urls = $artifacts['urls'] ?? [];
-        if (!is_array($urls)) {
-            $this->io->writeError("{$package->getName()}: Invalid extra.artifacts.urls config (expected object)");
+        $normalized = $this->normalizeArtifactsConfig($package, $artifacts);
+        if ($normalized === false) {
             return false;
         }
 
-        $validatedUrls = $this->validateArtifactUrls($package, $urls);
+        $validatedUrls = $this->validateArtifactUrls($package, $normalized['urls']);
         if ($matchingTemplate = Platform::findBestMatch($validatedUrls)) {
-            $vars = $this->resolveTemplateVars($package, $artifacts);
+            $vars = $this->resolveTemplateVars($package, $normalized['vars']);
             $resolvedUrl = $this->artifactUrlResolver->applyTemplate($matchingTemplate, $vars);
 
             $unresolved = $this->artifactUrlResolver->unresolvedPlaceholders($resolvedUrl);
@@ -71,6 +70,47 @@ class PlatformInstaller extends LibraryInstaller
 
         $this->io->writeError("{$package->getName()}: No download URL found for current platform");
         return false;
+    }
+
+    /**
+     * Supports two artifact formats:
+     * 1) Simple:   artifacts = { "darwin-arm64": "https://..." }
+     * 2) Extended: artifacts = { "urls": {...}, "vars": {...} }
+     *
+     * @param array<string, mixed> $artifacts
+     *
+     * @return array{urls: array<string, mixed>, vars: array<string, mixed>}|false
+     */
+    private function normalizeArtifactsConfig(PackageInterface $package, array $artifacts): array|false
+    {
+        if (array_key_exists('urls', $artifacts)) {
+            $urls = $artifacts['urls'];
+            if (!is_array($urls)) {
+                $this->io->writeError("{$package->getName()}: Invalid extra.artifacts.urls config (expected object)");
+                return false;
+            }
+
+            $vars = $artifacts['vars'] ?? [];
+            if (!is_array($vars)) {
+                $this->io->writeError("{$package->getName()}: Invalid extra.artifacts.vars config (expected object)");
+                return false;
+            }
+
+            return [
+                'urls' => $urls,
+                'vars' => $vars,
+            ];
+        }
+
+        if (array_key_exists('vars', $artifacts)) {
+            $this->io->writeError("{$package->getName()}: Invalid extra.artifacts config. Use extra.artifacts.urls when defining extra.artifacts.vars");
+            return false;
+        }
+
+        return [
+            'urls' => $artifacts,
+            'vars' => [],
+        ];
     }
 
     /**
@@ -117,17 +157,12 @@ class PlatformInstaller extends LibraryInstaller
     }
 
     /**
-     * @param array<string, mixed> $artifacts
+     * @param array<string, mixed> $defaultVars
      *
      * @return array<string, string>
      */
-    private function resolveTemplateVars(PackageInterface $package, array $artifacts): array
+    private function resolveTemplateVars(PackageInterface $package, array $defaultVars): array
     {
-        $defaultVars = $artifacts['vars'] ?? [];
-        if (!is_array($defaultVars)) {
-            $defaultVars = [];
-        }
-
         $rootExtra = $this->composer->getPackage()->getExtra();
         $platformPackages = $rootExtra['platform-packages'] ?? [];
         if (!is_array($platformPackages)) {

--- a/tests/ArtifactUrlResolverTest.php
+++ b/tests/ArtifactUrlResolverTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Codewithkyrian\PlatformPackageInstaller\ArtifactUrlResolver;
+
+it('merges vars with built-in version and prefers overrides', function () {
+    $resolver = new ArtifactUrlResolver();
+
+    $vars = $resolver->mergeVars(
+        ['cuda' => 12, 'channel' => 'stable', 'version' => 'nope'],
+        ['cuda' => 13],
+        '2.1.0'
+    );
+
+    expect($vars)->toMatchArray([
+        'cuda' => '13',
+        'channel' => 'stable',
+        'version' => '2.1.0',
+    ]);
+});
+
+it('applies placeholders and leaves unknown ones intact', function () {
+    $resolver = new ArtifactUrlResolver();
+
+    $out = $resolver->applyTemplate(
+        'https://cdn.example.com/{version}/cuda-{cuda}/dist-{platform}.tar.gz',
+        ['version' => '1.0.0', 'cuda' => '12']
+    );
+
+    expect($out)->toBe('https://cdn.example.com/1.0.0/cuda-12/dist-{platform}.tar.gz');
+    expect($resolver->unresolvedPlaceholders($out))->toBe(['platform']);
+});
+
+it('reports no unresolved placeholders when fully substituted', function () {
+    $resolver = new ArtifactUrlResolver();
+
+    $out = $resolver->applyTemplate(
+        'https://example.com/{version}/cuda-{cuda}.zip',
+        ['version' => '1.0.0', 'cuda' => '12']
+    );
+
+    expect($resolver->unresolvedPlaceholders($out))->toBe([]);
+});
+

--- a/tests/GenerateUrlCommandTest.php
+++ b/tests/GenerateUrlCommandTest.php
@@ -6,7 +6,6 @@ use Codewithkyrian\PlatformPackageInstaller\GenerateUrlCommand;
 use Composer\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Yaml\Yaml;
 
 beforeEach(function () {
     $application = new Application();
@@ -35,16 +34,9 @@ afterEach(function () {
 });
 
 it('generates platform URLs for GitHub', function () {
-    $platformsYaml = [
-        'linux-x86_64' => ['exclude' => []],
-        'darwin-arm64' => ['exclude' => []],
-        'windows-x86_64' => ['exclude' => []],
-    ];
-    file_put_contents($this->tempDir.'/platforms.yml', Yaml::dump($platformsYaml));
-
     $input = new ArrayInput([
         'command' => 'platform:generate-urls',
-        '--platforms-file' => $this->tempDir.'/platforms.yml',
+        '--platforms' => ['linux-x86_64', 'darwin-arm64', 'windows-x86_64'],
         '--dist-type' => 'github',
         '--repo-path' => 'vendor/repo',
     ]);
@@ -69,16 +61,10 @@ it('generates platform URLs for GitHub', function () {
 
 });
 
-it('uses the platforms file if not provided', function () {
-    $platformsYaml = [
-        'linux-x86_64' => ['exclude' => []],
-        'darwin-arm64' => ['exclude' => []],
-        'windows-x86_64' => ['exclude' => []],
-    ];
-    file_put_contents($this->tempDir.'/platforms.yml', Yaml::dump($platformsYaml));
-
+it('supports comma-separated platforms', function () {
     $input = new ArrayInput([
         'command' => 'platform:generate-urls',
+        '--platforms' => ['linux-x86_64,darwin-arm64,windows-x86_64'],
         '--dist-type' => 'github',
         '--repo-path' => 'vendor/repo',
     ]);
@@ -105,16 +91,9 @@ it('uses the platforms file if not provided', function () {
 });
 
 it('handles custom URL template', function () {
-    $platformsYaml = [
-        'linux-x86_64' => ['exclude' => []],
-        'darwin-arm64' => ['exclude' => []],
-    ];
-    file_put_contents($this->tempDir.'/platforms.yml', Yaml::dump($platformsYaml));
-
-    // Prepare command input with custom URL template
     $input = new ArrayInput([
         'command' => 'platform:generate-urls',
-        '--platforms-file' => $this->tempDir.'/platforms.yml',
+        '--platforms' => ['linux-x86_64', 'darwin-arm64'],
         '--dist-type' => 'https://custom-cdn.com/releases/{version}/dist-{platform}.{ext}',
         '--extension' => 'tar.xz',
     ]);
@@ -134,10 +113,9 @@ it('handles custom URL template', function () {
         ->and($platformUrls['darwin-arm64'])->toBe('https://custom-cdn.com/releases/{version}/dist-darwin-arm64.tar.xz');
 });
 
-it('fails with non-existent platforms file', function () {
+it('fails with no platforms provided', function () {
     $input = new ArrayInput([
         'command' => 'platform:generate-urls',
-        '--platforms-file' => '/path/to/non/existent/platforms.yml',
         '--dist-type' => 'github',
         '--repo-path' => 'vendor/repo',
     ]);
@@ -148,12 +126,10 @@ it('fails with non-existent platforms file', function () {
     expect($resultCode)->toBe(1);
 });
 
-it('handles empty platforms file', function () {
-    file_put_contents($this->tempDir.'/platforms.yml', '');
-
+it('deduplicates repeated platforms', function () {
     $input = new ArrayInput([
         'command' => 'platform:generate-urls',
-        '--platforms-file' => $this->tempDir.'/platforms.yml',
+        '--platforms' => ['linux-x86_64,darwin-arm64', 'darwin-arm64'],
         '--dist-type' => 'github',
         '--repo-path' => 'vendor/repo',
     ]);
@@ -166,15 +142,11 @@ it('handles empty platforms file', function () {
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
     expect($composerJson['extra']['artifacts'])->toBeArray()
-        ->and($composerJson['extra']['artifacts'])->toBeEmpty();
+        ->and($composerJson['extra']['artifacts'])->toHaveCount(2)
+        ->and($composerJson['extra']['artifacts'])->toHaveKeys(['linux-x86_64', 'darwin-arm64']);
 });
 
 it('merges with existing extra configuration', function () {
-    $platformsYaml = [
-        'linux-x86_64' => ['exclude' => []],
-    ];
-    file_put_contents($this->tempDir.'/platforms.yml', Yaml::dump($platformsYaml));
-
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
     $composerJson['extra'] = [
         'existing-config' => 'test-value'
@@ -183,7 +155,7 @@ it('merges with existing extra configuration', function () {
 
     $input = new ArrayInput([
         'command' => 'platform:generate-urls',
-        '--platforms-file' => $this->tempDir.'/platforms.yml',
+        '--platforms' => ['linux-x86_64'],
         '--dist-type' => 'github',
         '--repo-path' => 'vendor/repo',
     ]);
@@ -201,11 +173,6 @@ it('merges with existing extra configuration', function () {
 });
 
 it('keeps extended artifacts format when vars are already defined', function () {
-    $platformsYaml = [
-        'linux-x86_64' => ['exclude' => []],
-    ];
-    file_put_contents($this->tempDir.'/platforms.yml', Yaml::dump($platformsYaml));
-
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
     $composerJson['extra'] = [
         'artifacts' => [
@@ -218,7 +185,7 @@ it('keeps extended artifacts format when vars are already defined', function () 
 
     $input = new ArrayInput([
         'command' => 'platform:generate-urls',
-        '--platforms-file' => $this->tempDir.'/platforms.yml',
+        '--platforms' => ['linux-x86_64'],
         '--dist-type' => 'github',
         '--repo-path' => 'vendor/repo',
     ]);

--- a/tests/GenerateUrlCommandTest.php
+++ b/tests/GenerateUrlCommandTest.php
@@ -58,10 +58,9 @@ it('generates platform URLs for GitHub', function () {
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
     expect($composerJson)->toHaveKey('extra')
-        ->and($composerJson['extra'])->toHaveKey('artifacts')
-        ->and($composerJson['extra']['artifacts'])->toHaveKey('urls');
+        ->and($composerJson['extra'])->toHaveKey('artifacts');
 
-    $platformUrls = $composerJson['extra']['artifacts']['urls'];
+    $platformUrls = $composerJson['extra']['artifacts'];
 
     expect($platformUrls)->toHaveCount(3)
         ->and($platformUrls['linux-x86_64'])->toBe('https://github.com/vendor/repo/releases/download/{version}/dist-linux-x86_64.tar.gz')
@@ -93,10 +92,9 @@ it('uses the platforms file if not provided', function () {
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
     expect($composerJson)->toHaveKey('extra')
-        ->and($composerJson['extra'])->toHaveKey('artifacts')
-        ->and($composerJson['extra']['artifacts'])->toHaveKey('urls');
+        ->and($composerJson['extra'])->toHaveKey('artifacts');
 
-    $platformUrls = $composerJson['extra']['artifacts']['urls'];
+    $platformUrls = $composerJson['extra']['artifacts'];
 
     expect($platformUrls)->toHaveCount(3)
         ->and($platformUrls['linux-x86_64'])->toBe('https://github.com/vendor/repo/releases/download/{version}/dist-linux-x86_64.tar.gz')
@@ -129,7 +127,7 @@ it('handles custom URL template', function () {
 
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
-    $platformUrls = $composerJson['extra']['artifacts']['urls'];
+    $platformUrls = $composerJson['extra']['artifacts'];
 
     expect($platformUrls)->toHaveCount(2)
         ->and($platformUrls['linux-x86_64'])->toBe('https://custom-cdn.com/releases/{version}/dist-linux-x86_64.tar.xz')
@@ -167,8 +165,8 @@ it('handles empty platforms file', function () {
 
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
-    expect($composerJson['extra']['artifacts']['urls'])->toBeArray()
-        ->and($composerJson['extra']['artifacts']['urls'])->toBeEmpty();
+    expect($composerJson['extra']['artifacts'])->toBeArray()
+        ->and($composerJson['extra']['artifacts'])->toBeEmpty();
 });
 
 it('merges with existing extra configuration', function () {
@@ -198,6 +196,40 @@ it('merges with existing extra configuration', function () {
     $updatedComposerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
     expect($updatedComposerJson['extra']['existing-config'])->toBe('test-value')
-        ->and($updatedComposerJson['extra']['artifacts']['urls'])->toHaveCount(1)
+        ->and($updatedComposerJson['extra']['artifacts'])->toHaveCount(1)
+        ->and($updatedComposerJson['extra']['artifacts']['linux-x86_64'])->toBe('https://github.com/vendor/repo/releases/download/{version}/dist-linux-x86_64.tar.gz');
+});
+
+it('keeps extended artifacts format when vars are already defined', function () {
+    $platformsYaml = [
+        'linux-x86_64' => ['exclude' => []],
+    ];
+    file_put_contents($this->tempDir.'/platforms.yml', Yaml::dump($platformsYaml));
+
+    $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
+    $composerJson['extra'] = [
+        'artifacts' => [
+            'vars' => [
+                'cuda' => '12',
+            ],
+        ],
+    ];
+    file_put_contents($this->tempDir.'/composer.json', json_encode($composerJson));
+
+    $input = new ArrayInput([
+        'command' => 'platform:generate-urls',
+        '--platforms-file' => $this->tempDir.'/platforms.yml',
+        '--dist-type' => 'github',
+        '--repo-path' => 'vendor/repo',
+    ]);
+
+    $output = new BufferedOutput();
+    $resultCode = $this->command->run($input, $output);
+
+    expect($resultCode)->toBe(0);
+
+    $updatedComposerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
+
+    expect($updatedComposerJson['extra']['artifacts']['vars']['cuda'])->toBe('12')
         ->and($updatedComposerJson['extra']['artifacts']['urls']['linux-x86_64'])->toBe('https://github.com/vendor/repo/releases/download/{version}/dist-linux-x86_64.tar.gz');
 });

--- a/tests/GenerateUrlCommandTest.php
+++ b/tests/GenerateUrlCommandTest.php
@@ -58,9 +58,10 @@ it('generates platform URLs for GitHub', function () {
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
     expect($composerJson)->toHaveKey('extra')
-        ->and($composerJson['extra'])->toHaveKey('platform-urls');
+        ->and($composerJson['extra'])->toHaveKey('artifacts')
+        ->and($composerJson['extra']['artifacts'])->toHaveKey('urls');
 
-    $platformUrls = $composerJson['extra']['platform-urls'];
+    $platformUrls = $composerJson['extra']['artifacts']['urls'];
 
     expect($platformUrls)->toHaveCount(3)
         ->and($platformUrls['linux-x86_64'])->toBe('https://github.com/vendor/repo/releases/download/{version}/dist-linux-x86_64.tar.gz')
@@ -92,9 +93,10 @@ it('uses the platforms file if not provided', function () {
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
     expect($composerJson)->toHaveKey('extra')
-        ->and($composerJson['extra'])->toHaveKey('platform-urls');
+        ->and($composerJson['extra'])->toHaveKey('artifacts')
+        ->and($composerJson['extra']['artifacts'])->toHaveKey('urls');
 
-    $platformUrls = $composerJson['extra']['platform-urls'];
+    $platformUrls = $composerJson['extra']['artifacts']['urls'];
 
     expect($platformUrls)->toHaveCount(3)
         ->and($platformUrls['linux-x86_64'])->toBe('https://github.com/vendor/repo/releases/download/{version}/dist-linux-x86_64.tar.gz')
@@ -127,7 +129,7 @@ it('handles custom URL template', function () {
 
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
-    $platformUrls = $composerJson['extra']['platform-urls'];
+    $platformUrls = $composerJson['extra']['artifacts']['urls'];
 
     expect($platformUrls)->toHaveCount(2)
         ->and($platformUrls['linux-x86_64'])->toBe('https://custom-cdn.com/releases/{version}/dist-linux-x86_64.tar.xz')
@@ -165,8 +167,8 @@ it('handles empty platforms file', function () {
 
     $composerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
-    expect($composerJson['extra']['platform-urls'])->toBeArray()
-        ->and($composerJson['extra']['platform-urls'])->toBeEmpty();
+    expect($composerJson['extra']['artifacts']['urls'])->toBeArray()
+        ->and($composerJson['extra']['artifacts']['urls'])->toBeEmpty();
 });
 
 it('merges with existing extra configuration', function () {
@@ -196,6 +198,6 @@ it('merges with existing extra configuration', function () {
     $updatedComposerJson = json_decode(file_get_contents($this->tempDir.'/composer.json'), true);
 
     expect($updatedComposerJson['extra']['existing-config'])->toBe('test-value')
-        ->and($updatedComposerJson['extra']['platform-urls'])->toHaveCount(1)
-        ->and($updatedComposerJson['extra']['platform-urls']['linux-x86_64'])->toBe('https://github.com/vendor/repo/releases/download/{version}/dist-linux-x86_64.tar.gz');
+        ->and($updatedComposerJson['extra']['artifacts']['urls'])->toHaveCount(1)
+        ->and($updatedComposerJson['extra']['artifacts']['urls']['linux-x86_64'])->toBe('https://github.com/vendor/repo/releases/download/{version}/dist-linux-x86_64.tar.gz');
 });

--- a/tests/GenerateUrlCommandTest.php
+++ b/tests/GenerateUrlCommandTest.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use Codewithkyrian\PlatformPackageInstaller\GenerateUrlCommand;
-use Composer\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Application;
 
 beforeEach(function () {
     $application = new Application();

--- a/tests/GenerateUrlCommandTest.php
+++ b/tests/GenerateUrlCommandTest.php
@@ -10,7 +10,11 @@ use Symfony\Component\Console\Application;
 beforeEach(function () {
     $application = new Application();
     $urlGeneratorCommand = new GenerateUrlCommand();
-    $application->add($urlGeneratorCommand);
+    if (method_exists($application, 'add')) {
+        $application->add($urlGeneratorCommand);
+    } elseif (method_exists($application, 'addCommand')) {
+        $application->addCommand($urlGeneratorCommand);
+    }
     $application->setAutoExit(false);
     $this->command = $application->find('platform:generate-urls');
 

--- a/tests/Integration/ComposerInstallTest.php
+++ b/tests/Integration/ComposerInstallTest.php
@@ -398,9 +398,11 @@ function runCommand(array $command, string $cwd, array $env = [], int $timeoutSe
     fclose($pipes[0]);
 
     $start = time();
+    $finalStatus = null;
     while (true) {
         $status = proc_get_status($process);
         if ($status['running'] === false) {
+            $finalStatus = $status;
             break;
         }
 
@@ -418,6 +420,11 @@ function runCommand(array $command, string $cwd, array $env = [], int $timeoutSe
     fclose($pipes[2]);
 
     $exitCode = proc_close($process);
+    if ($exitCode === -1 && is_array($finalStatus) && isset($finalStatus['exitcode']) && is_int($finalStatus['exitcode'])) {
+        // proc_close can return -1 on some PHP versions after polling with proc_get_status.
+        $exitCode = $finalStatus['exitcode'];
+    }
+
     return [
         'exit_code' => $exitCode,
         'stdout' => $stdout,

--- a/tests/Integration/ComposerInstallTest.php
+++ b/tests/Integration/ComposerInstallTest.php
@@ -1,0 +1,468 @@
+<?php
+
+declare(strict_types=1);
+
+it('installs platform package using root override vars', function () {
+    if (!class_exists(ZipArchive::class)) {
+        $this->markTestSkipped('ZipArchive extension is required for integration test.');
+    }
+
+    $repoRoot = realpath(__DIR__.'/../../');
+    expect($repoRoot)->not->toBeFalse();
+    $repoRoot = (string) $repoRoot;
+
+    $tmpRoot = sys_get_temp_dir().DIRECTORY_SEPARATOR.'platform-package-installer-int-'.uniqid();
+    $pluginCopyPath = $tmpRoot.DIRECTORY_SEPARATOR.'plugin-under-test';
+    $distPath = $tmpRoot.DIRECTORY_SEPARATOR.'dist';
+    $appPath = $tmpRoot.DIRECTORY_SEPARATOR.'app';
+
+    mkdir($tmpRoot, 0777, true);
+    mkdir($distPath, 0777, true);
+    mkdir($appPath, 0777, true);
+
+    $serverProcess = null;
+    try {
+        copyPluginForPathRepository($repoRoot, $pluginCopyPath);
+        relaxPluginDependenciesForIntegration($pluginCopyPath, '2.0.0');
+
+        createZipArtifact($distPath.DIRECTORY_SEPARATOR.'onyx-runtime-1.2.3-cuda-12.zip', '12');
+        createZipArtifact($distPath.DIRECTORY_SEPARATOR.'onyx-runtime-1.2.3-cuda-13.zip', '13');
+
+        $port = reserveFreePort();
+        $serverProcess = startPhpServer($distPath, $port);
+
+        waitForServerReady("http://127.0.0.1:$port/onyx-runtime-1.2.3-cuda-13.zip");
+
+        $template = "http://127.0.0.1:$port/onyx-runtime-{version}-cuda-{cuda}.zip";
+        $appComposerJson = [
+            'name' => 'integration/test-app',
+            'type' => 'project',
+            'require' => [
+                'codewithkyrian/platform-package-installer' => '2.0.0',
+                'org/onyx-runtime' => '1.2.3',
+            ],
+            'repositories' => [
+                ['packagist.org' => false],
+                [
+                    'type' => 'path',
+                    'url' => $pluginCopyPath,
+                    'options' => ['symlink' => false],
+                ],
+                [
+                    'type' => 'package',
+                    'package' => [
+                        'name' => 'org/onyx-runtime',
+                        'version' => '1.2.3',
+                        'type' => 'platform-package',
+                        'dist' => [
+                            'url' => $template,
+                            'type' => 'zip',
+                        ],
+                        'extra' => [
+                            'artifacts' => [
+                                'urls' => [
+                                    'all' => $template,
+                                ],
+                                'vars' => [
+                                    'cuda' => '12',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'extra' => [
+                'platform-packages' => [
+                    'org/onyx-runtime' => [
+                        'cuda' => '13',
+                    ],
+                ],
+            ],
+            'config' => [
+                'allow-plugins' => [
+                    'codewithkyrian/platform-package-installer' => true,
+                ],
+                'secure-http' => false,
+            ],
+        ];
+
+        file_put_contents(
+            $appPath.DIRECTORY_SEPARATOR.'composer.json',
+            json_encode($appComposerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $composerBin = findComposerBinary($repoRoot);
+        $install = runCommand(
+            [PHP_BINARY, $composerBin, 'install', '--no-interaction', '--no-progress'],
+            $appPath,
+            [
+                'COMPOSER_CACHE_DIR' => $tmpRoot.DIRECTORY_SEPARATOR.'cache',
+                'COMPOSER_HOME' => $tmpRoot.DIRECTORY_SEPARATOR.'home',
+            ],
+            120
+        );
+
+        if ($install['exit_code'] !== 0) {
+            throw new RuntimeException(
+                "composer install failed\nSTDERR:\n".$install['stderr']."\nSTDOUT:\n".$install['stdout']
+            );
+        }
+
+        $marker = $appPath.DIRECTORY_SEPARATOR.'vendor/org/onyx-runtime/cuda-version.txt';
+        expect(file_exists($marker))->toBeTrue();
+        expect(trim((string) file_get_contents($marker)))->toBe('13');
+    } finally {
+        if (is_array($serverProcess)) {
+            stopProcess($serverProcess);
+        }
+
+        if (is_dir($tmpRoot)) {
+            removeDirectoryRecursive($tmpRoot);
+        }
+    }
+});
+
+it('falls back to base dist URL when a required artifact variable is missing', function () {
+    if (!class_exists(ZipArchive::class)) {
+        $this->markTestSkipped('ZipArchive extension is required for integration test.');
+    }
+
+    $repoRoot = realpath(__DIR__.'/../../');
+    expect($repoRoot)->not->toBeFalse();
+    $repoRoot = (string) $repoRoot;
+
+    $tmpRoot = sys_get_temp_dir().DIRECTORY_SEPARATOR.'platform-package-installer-int-'.uniqid();
+    $pluginCopyPath = $tmpRoot.DIRECTORY_SEPARATOR.'plugin-under-test';
+    $distPath = $tmpRoot.DIRECTORY_SEPARATOR.'dist';
+    $appPath = $tmpRoot.DIRECTORY_SEPARATOR.'app';
+
+    mkdir($tmpRoot, 0777, true);
+    mkdir($distPath, 0777, true);
+    mkdir($appPath, 0777, true);
+
+    $serverProcess = null;
+    try {
+        copyPluginForPathRepository($repoRoot, $pluginCopyPath);
+        relaxPluginDependenciesForIntegration($pluginCopyPath, '2.0.0');
+
+        createZipArtifact($distPath.DIRECTORY_SEPARATOR.'fallback.zip', 'fallback');
+
+        $port = reserveFreePort();
+        $serverProcess = startPhpServer($distPath, $port);
+
+        waitForServerReady("http://127.0.0.1:$port/fallback.zip");
+
+        $artifactTemplate = "http://127.0.0.1:$port/onyx-runtime-{version}-cuda-{cuda}.zip";
+        $fallbackUrl = "http://127.0.0.1:$port/fallback.zip";
+
+        $appComposerJson = [
+            'name' => 'integration/test-app-fallback',
+            'type' => 'project',
+            'require' => [
+                'codewithkyrian/platform-package-installer' => '2.0.0',
+                'org/onyx-runtime' => '1.2.3',
+            ],
+            'repositories' => [
+                ['packagist.org' => false],
+                [
+                    'type' => 'path',
+                    'url' => $pluginCopyPath,
+                    'options' => ['symlink' => false],
+                ],
+                [
+                    'type' => 'package',
+                    'package' => [
+                        'name' => 'org/onyx-runtime',
+                        'version' => '1.2.3',
+                        'type' => 'platform-package',
+                        'dist' => [
+                            'url' => $fallbackUrl,
+                            'type' => 'zip',
+                        ],
+                        'extra' => [
+                            'artifacts' => [
+                                'urls' => [
+                                    'all' => $artifactTemplate,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'config' => [
+                'allow-plugins' => [
+                    'codewithkyrian/platform-package-installer' => true,
+                ],
+                'secure-http' => false,
+            ],
+        ];
+
+        file_put_contents(
+            $appPath.DIRECTORY_SEPARATOR.'composer.json',
+            json_encode($appComposerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $composerBin = findComposerBinary($repoRoot);
+        $install = runCommand(
+            [PHP_BINARY, $composerBin, 'install', '--no-interaction', '--no-progress'],
+            $appPath,
+            [
+                'COMPOSER_CACHE_DIR' => $tmpRoot.DIRECTORY_SEPARATOR.'cache',
+                'COMPOSER_HOME' => $tmpRoot.DIRECTORY_SEPARATOR.'home',
+            ],
+            120
+        );
+
+        if ($install['exit_code'] !== 0) {
+            throw new RuntimeException(
+                "composer install failed\nSTDERR:\n".$install['stderr']."\nSTDOUT:\n".$install['stdout']
+            );
+        }
+
+        $marker = $appPath.DIRECTORY_SEPARATOR.'vendor/org/onyx-runtime/cuda-version.txt';
+        expect(file_exists($marker))->toBeTrue();
+        expect(trim((string) file_get_contents($marker)))->toBe('fallback');
+    } finally {
+        if (is_array($serverProcess)) {
+            stopProcess($serverProcess);
+        }
+
+        if (is_dir($tmpRoot)) {
+            removeDirectoryRecursive($tmpRoot);
+        }
+    }
+});
+
+/**
+ * @return array{process: resource, stdout: resource, stderr: resource}
+ */
+function startPhpServer(string $documentRoot, int $port): array
+{
+    $cmd = sprintf(
+        '%s -S %s -t %s',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg("127.0.0.1:$port"),
+        escapeshellarg($documentRoot)
+    );
+
+    $descriptorSpec = [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+
+    $process = proc_open($cmd, $descriptorSpec, $pipes);
+    if (!is_resource($process)) {
+        throw new RuntimeException('Unable to start local PHP server.');
+    }
+
+    fclose($pipes[0]);
+    stream_set_blocking($pipes[1], false);
+    stream_set_blocking($pipes[2], false);
+
+    return [
+        'process' => $process,
+        'stdout' => $pipes[1],
+        'stderr' => $pipes[2],
+    ];
+}
+
+/**
+ * @param array<int, string> $command
+ * @param array<string, string> $env
+ *
+ * @return array{exit_code: int, stdout: string, stderr: string}
+ */
+function runCommand(array $command, string $cwd, array $env = [], int $timeoutSeconds = 60): array
+{
+    $cmd = implode(' ', array_map('escapeshellarg', $command));
+    $descriptorSpec = [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+
+    $process = proc_open($cmd, $descriptorSpec, $pipes, $cwd, array_merge($_ENV, $env));
+    if (!is_resource($process)) {
+        throw new RuntimeException("Unable to run command: $cmd");
+    }
+
+    fclose($pipes[0]);
+
+    $start = time();
+    while (true) {
+        $status = proc_get_status($process);
+        if ($status['running'] === false) {
+            break;
+        }
+
+        if ((time() - $start) > $timeoutSeconds) {
+            proc_terminate($process);
+            throw new RuntimeException("Command timed out after {$timeoutSeconds}s: $cmd");
+        }
+
+        usleep(100_000);
+    }
+
+    $stdout = (string) stream_get_contents($pipes[1]);
+    $stderr = (string) stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+
+    $exitCode = proc_close($process);
+    return [
+        'exit_code' => $exitCode,
+        'stdout' => $stdout,
+        'stderr' => $stderr,
+    ];
+}
+
+/**
+ * @param array{process: resource, stdout: resource, stderr: resource} $processData
+ */
+function stopProcess(array $processData): void
+{
+    if (is_resource($processData['stdout'])) {
+        fclose($processData['stdout']);
+    }
+    if (is_resource($processData['stderr'])) {
+        fclose($processData['stderr']);
+    }
+    if (is_resource($processData['process'])) {
+        proc_terminate($processData['process']);
+        proc_close($processData['process']);
+    }
+}
+
+function copyPluginForPathRepository(string $sourceRoot, string $targetRoot): void
+{
+    mkdir($targetRoot, 0777, true);
+
+    $skip = [
+        '.git',
+        '.idea',
+        '.cursor',
+        'vendor',
+        'tests',
+    ];
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($sourceRoot, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+
+    foreach ($iterator as $item) {
+        $relative = substr($item->getPathname(), strlen($sourceRoot) + 1);
+        $firstPart = explode(DIRECTORY_SEPARATOR, $relative)[0];
+
+        if (in_array($firstPart, $skip, true)) {
+            continue;
+        }
+
+        $dest = $targetRoot.DIRECTORY_SEPARATOR.$relative;
+        if ($item->isDir()) {
+            if (!is_dir($dest)) {
+                mkdir($dest, 0777, true);
+            }
+
+            continue;
+        }
+
+        copy($item->getPathname(), $dest);
+    }
+}
+
+function relaxPluginDependenciesForIntegration(string $pluginRoot, string $version): void
+{
+    $composerPath = $pluginRoot.DIRECTORY_SEPARATOR.'composer.json';
+    $composer = json_decode((string) file_get_contents($composerPath), true);
+
+    $composer['version'] = $version;
+    $composer['require'] = [
+        'php' => '^8.1',
+        'composer-plugin-api' => '^1.1 || ^2.0',
+        'composer-runtime-api' => '*',
+    ];
+    unset($composer['require-dev']);
+
+    file_put_contents($composerPath, json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+}
+
+function createZipArtifact(string $zipPath, string $cudaVersion): void
+{
+    $zip = new ZipArchive();
+    $ok = $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    if ($ok !== true) {
+        throw new RuntimeException("Unable to create archive: $zipPath");
+    }
+
+    $zip->addFromString('cuda-version.txt', $cudaVersion.PHP_EOL);
+    $zip->addFromString('README.txt', 'integration artifact');
+    $zip->close();
+}
+
+function reserveFreePort(): int
+{
+    $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+    if ($socket === false) {
+        throw new RuntimeException("Unable to reserve a free port: $error");
+    }
+
+    $name = stream_socket_get_name($socket, false);
+    fclose($socket);
+
+    if (!is_string($name) || !str_contains($name, ':')) {
+        throw new RuntimeException('Unable to read reserved port.');
+    }
+
+    return (int) substr($name, strrpos($name, ':') + 1);
+}
+
+function waitForServerReady(string $url): void
+{
+    $attempts = 20;
+    for ($i = 0; $i < $attempts; $i++) {
+        usleep(100_000);
+        $headers = @get_headers($url);
+        if (is_array($headers) && isset($headers[0]) && str_contains($headers[0], '200')) {
+            return;
+        }
+    }
+
+    throw new RuntimeException("Local artifact server did not become ready for URL: $url");
+}
+
+function findComposerBinary(string $repoRoot): string
+{
+    $localComposer = $repoRoot.DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'composer';
+    if (file_exists($localComposer)) {
+        return $localComposer;
+    }
+
+    $whichComposer = trim((string) shell_exec('which composer'));
+    if ($whichComposer !== '' && file_exists($whichComposer)) {
+        return $whichComposer;
+    }
+
+    throw new RuntimeException('Composer binary not found. Ensure vendor/bin/composer or global composer is available.');
+}
+
+function removeDirectoryRecursive(string $path): void
+{
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($iterator as $item) {
+        if ($item->isDir()) {
+            rmdir($item->getPathname());
+            continue;
+        }
+
+        unlink($item->getPathname());
+    }
+
+    rmdir($path);
+}
+

--- a/tests/Integration/ComposerInstallTest.php
+++ b/tests/Integration/ComposerInstallTest.php
@@ -233,6 +233,114 @@ it('falls back to base dist URL when a required artifact variable is missing', f
     }
 });
 
+it('installs platform package from simple artifacts format without vars', function () {
+    if (!class_exists(ZipArchive::class)) {
+        $this->markTestSkipped('ZipArchive extension is required for integration test.');
+    }
+
+    $repoRoot = realpath(__DIR__.'/../../');
+    expect($repoRoot)->not->toBeFalse();
+    $repoRoot = (string) $repoRoot;
+
+    $tmpRoot = sys_get_temp_dir().DIRECTORY_SEPARATOR.'platform-package-installer-int-'.uniqid();
+    $pluginCopyPath = $tmpRoot.DIRECTORY_SEPARATOR.'plugin-under-test';
+    $distPath = $tmpRoot.DIRECTORY_SEPARATOR.'dist';
+    $appPath = $tmpRoot.DIRECTORY_SEPARATOR.'app';
+
+    mkdir($tmpRoot, 0777, true);
+    mkdir($distPath, 0777, true);
+    mkdir($appPath, 0777, true);
+
+    $serverProcess = null;
+    try {
+        copyPluginForPathRepository($repoRoot, $pluginCopyPath);
+        relaxPluginDependenciesForIntegration($pluginCopyPath, '2.0.0');
+
+        createZipArtifact($distPath.DIRECTORY_SEPARATOR.'onyx-runtime-1.2.3.zip', 'simple');
+
+        $port = reserveFreePort();
+        $serverProcess = startPhpServer($distPath, $port);
+
+        waitForServerReady("http://127.0.0.1:$port/onyx-runtime-1.2.3.zip");
+
+        $artifactTemplate = "http://127.0.0.1:$port/onyx-runtime-{version}.zip";
+
+        $appComposerJson = [
+            'name' => 'integration/test-app-simple-format',
+            'type' => 'project',
+            'require' => [
+                'codewithkyrian/platform-package-installer' => '2.0.0',
+                'org/onyx-runtime' => '1.2.3',
+            ],
+            'repositories' => [
+                ['packagist.org' => false],
+                [
+                    'type' => 'path',
+                    'url' => $pluginCopyPath,
+                    'options' => ['symlink' => false],
+                ],
+                [
+                    'type' => 'package',
+                    'package' => [
+                        'name' => 'org/onyx-runtime',
+                        'version' => '1.2.3',
+                        'type' => 'platform-package',
+                        'dist' => [
+                            'url' => "http://127.0.0.1:$port/should-not-be-used.zip",
+                            'type' => 'zip',
+                        ],
+                        'extra' => [
+                            'artifacts' => [
+                                'all' => $artifactTemplate,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'config' => [
+                'allow-plugins' => [
+                    'codewithkyrian/platform-package-installer' => true,
+                ],
+                'secure-http' => false,
+            ],
+        ];
+
+        file_put_contents(
+            $appPath.DIRECTORY_SEPARATOR.'composer.json',
+            json_encode($appComposerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $composerBin = findComposerBinary($repoRoot);
+        $install = runCommand(
+            [PHP_BINARY, $composerBin, 'install', '--no-interaction', '--no-progress'],
+            $appPath,
+            [
+                'COMPOSER_CACHE_DIR' => $tmpRoot.DIRECTORY_SEPARATOR.'cache',
+                'COMPOSER_HOME' => $tmpRoot.DIRECTORY_SEPARATOR.'home',
+            ],
+            120
+        );
+
+        if ($install['exit_code'] !== 0) {
+            throw new RuntimeException(
+                "composer install failed\nSTDERR:\n".$install['stderr']."\nSTDOUT:\n".$install['stdout']
+            );
+        }
+
+        $marker = $appPath.DIRECTORY_SEPARATOR.'vendor/org/onyx-runtime/cuda-version.txt';
+        expect(file_exists($marker))->toBeTrue();
+        expect(trim((string) file_get_contents($marker)))->toBe('simple');
+    } finally {
+        if (is_array($serverProcess)) {
+            stopProcess($serverProcess);
+        }
+
+        if (is_dir($tmpRoot)) {
+            removeDirectoryRecursive($tmpRoot);
+        }
+    }
+});
+
 /**
  * @return array{process: resource, stdout: resource, stderr: resource}
  */


### PR DESCRIPTION
This PR changes package distribution configuration from platform-urls to artifacts, and adds support for custom template variables in artifact URL templates. It also keeps simple flat platform URL entries while supporting the expanded urls + vars shape, updates the URL generator command to use CLI platform input instead of platforms.yml, and adds integration tests to validate real Composer install behavior.

## Motivation and Context
The package core is platform-aware install URL resolution. The previous setup was limited to `{version}` and a single flat config key (`platform-urls`). This PR expands that model so package authors can define reusable URL templates with additional variables and allow consuming applications to override those values when needed, while still supporting simple setups. The command and test updates ensure the new model is practical and reliable in real-world install flows.

## What Changed
- Renamed package config key from `extra.platform-urls` to `extra.artifacts`.
- Added support for custom placeholders in artifact URL templates (beyond `{version}`).
- Added package-level default variables via `extra.artifacts.vars`.
- Added application-level variable overrides via `extra.platform-packages.<package-name>`.
- Supported both artifact config styles under `extra.artifacts`: flat platform map and nested urls + vars.
- Updated installer logic to resolve variables, apply templates, and fallback safely when unresolved.
- Updated `platform:generate-urls` to accept platforms from CLI (`--platforms`) and stop using `platforms.yml`.
- Updated and expanded tests, including real integration tests for install success and fallback behavior.
- Rewrote `README` to center on core package behavior and new configuration model.
- Removed `symfony/yaml` dependency.

## Breaking Changes
- `extra.platform-urls` is replaced by `extra.artifacts`.
- Variable-based URL templating is now part of the config model (vars + overrides).
- `platform:generate-urls` no longer reads `platforms.yml`.
- Platforms for generation must now be provided through `--platforms`.
