### PR TITLE
Feat: add default-variable fallback when override-resolved artifact URL fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Variable precedence:
 - `{version}` is built in and always available
 - Any `{name}` placeholder can be used
 - Unresolved placeholders cause artifact URL resolution to fail for that package
+- If override variables resolve to a URL that does not exist, the plugin retries with package default variables
 - On failure, Composer falls back to the package's original `dist` configuration
 
 ## Platform Matching

--- a/src/PlatformInstaller.php
+++ b/src/PlatformInstaller.php
@@ -45,26 +45,36 @@ class PlatformInstaller extends LibraryInstaller
 
         $validatedUrls = $this->validateArtifactUrls($package, $normalized['urls']);
         if ($matchingTemplate = Platform::findBestMatch($validatedUrls)) {
-            $vars = $this->resolveTemplateVars($package, $normalized['vars']);
-            $resolvedUrl = $this->artifactUrlResolver->applyTemplate($matchingTemplate, $vars);
+            $defaultVars = $this->normalizeVars($normalized['vars']);
+            $overrideVars = $this->resolveOverrideVars($package);
+            $hasOverrides = $overrideVars !== [];
 
-            $unresolved = $this->artifactUrlResolver->unresolvedPlaceholders($resolvedUrl);
-            if ($unresolved !== []) {
-                $missing = implode(', ', array_map(fn($k) => '{'.$k.'}', $unresolved));
-                $this->io->writeError("{$package->getName()}: Unresolved URL placeholders: {$missing}");
+            $primaryVars = $this->artifactUrlResolver->mergeVars($defaultVars, $overrideVars, $package->getPrettyVersion());
+            $primaryResult = $this->resolveCandidateUrl($matchingTemplate, $primaryVars);
+            if ($primaryResult['url'] !== false) {
+                return $primaryResult['url'];
+            }
+
+            if ($hasOverrides) {
+                $fallbackVars = $this->artifactUrlResolver->mergeVars($defaultVars, [], $package->getPrettyVersion());
+                $fallbackResult = $this->resolveCandidateUrl($matchingTemplate, $fallbackVars);
+
+                if ($fallbackResult['url'] !== false) {
+                    $this->io->writeError(
+                        "{$package->getName()}: Override-resolved artifact URL failed ({$primaryResult['reason']}). ".
+                        "Falling back to package default variables URL: {$fallbackResult['url']}"
+                    );
+                    return $fallbackResult['url'];
+                }
+
+                $this->io->writeError(
+                    "{$package->getName()}: Override-resolved artifact URL failed ({$primaryResult['reason']}). ".
+                    "Default-variable fallback also failed ({$fallbackResult['reason']})."
+                );
                 return false;
             }
 
-            if (!filter_var($resolvedUrl, FILTER_VALIDATE_URL)) {
-                $this->io->writeError("{$package->getName()}: Invalid resolved URL: $resolvedUrl");
-                return false;
-            }
-
-            if ($this->urlExists($resolvedUrl)) {
-                return $resolvedUrl;
-            }
-
-            $this->io->writeError("{$package->getName()}: URL found for current platform but it doesn't exist: $resolvedUrl");
+            $this->io->writeError("{$package->getName()}: {$primaryResult['reason']}");
             return false;
         }
 
@@ -156,12 +166,7 @@ class PlatformInstaller extends LibraryInstaller
         return $validatedPlatforms;
     }
 
-    /**
-     * @param array<string, mixed> $defaultVars
-     *
-     * @return array<string, string>
-     */
-    private function resolveTemplateVars(PackageInterface $package, array $defaultVars): array
+    private function resolveOverrideVars(PackageInterface $package): array
     {
         $rootExtra = $this->composer->getPackage()->getExtra();
         $platformPackages = $rootExtra['platform-packages'] ?? [];
@@ -174,7 +179,64 @@ class PlatformInstaller extends LibraryInstaller
             $overrideVars = [];
         }
 
-        return $this->artifactUrlResolver->mergeVars($defaultVars, $overrideVars, $package->getPrettyVersion());
+        return $this->normalizeVars($overrideVars);
+    }
+
+    /**
+     * @param array<string, mixed> $vars
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeVars(array $vars): array
+    {
+        $normalized = [];
+        foreach ($vars as $key => $value) {
+            if (!is_string($key) || $key === '') {
+                continue;
+            }
+
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string, string> $vars
+     *
+     * @return array{url: string|false, reason: string}
+     */
+    private function resolveCandidateUrl(string $template, array $vars): array
+    {
+        $resolvedUrl = $this->artifactUrlResolver->applyTemplate($template, $vars);
+
+        $unresolved = $this->artifactUrlResolver->unresolvedPlaceholders($resolvedUrl);
+        if ($unresolved !== []) {
+            $missing = implode(', ', array_map(fn($k) => '{'.$k.'}', $unresolved));
+            return [
+                'url' => false,
+                'reason' => "Unresolved URL placeholders: {$missing}",
+            ];
+        }
+
+        if (!filter_var($resolvedUrl, FILTER_VALIDATE_URL)) {
+            return [
+                'url' => false,
+                'reason' => "Invalid resolved URL: {$resolvedUrl}",
+            ];
+        }
+
+        if (!$this->urlExists($resolvedUrl)) {
+            return [
+                'url' => false,
+                'reason' => "URL found for current platform but it doesn't exist: {$resolvedUrl}",
+            ];
+        }
+
+        return [
+            'url' => $resolvedUrl,
+            'reason' => 'ok',
+        ];
     }
 
     private function inferArchiveType(string $url): string

--- a/tests/Integration/ComposerInstallTest.php
+++ b/tests/Integration/ComposerInstallTest.php
@@ -122,6 +122,128 @@ it('installs platform package using root override vars', function () {
     }
 });
 
+it('falls back to package default variables when override-resolved URL does not exist', function () {
+    if (!class_exists(ZipArchive::class)) {
+        $this->markTestSkipped('ZipArchive extension is required for integration test.');
+    }
+
+    $repoRoot = realpath(__DIR__.'/../../');
+    expect($repoRoot)->not->toBeFalse();
+    $repoRoot = (string) $repoRoot;
+
+    $tmpRoot = sys_get_temp_dir().DIRECTORY_SEPARATOR.'platform-package-installer-int-'.uniqid();
+    $pluginCopyPath = $tmpRoot.DIRECTORY_SEPARATOR.'plugin-under-test';
+    $distPath = $tmpRoot.DIRECTORY_SEPARATOR.'dist';
+    $appPath = $tmpRoot.DIRECTORY_SEPARATOR.'app';
+
+    mkdir($tmpRoot, 0777, true);
+    mkdir($distPath, 0777, true);
+    mkdir($appPath, 0777, true);
+
+    $serverProcess = null;
+    try {
+        copyPluginForPathRepository($repoRoot, $pluginCopyPath);
+        relaxPluginDependenciesForIntegration($pluginCopyPath, '2.0.0');
+
+        createZipArtifact($distPath.DIRECTORY_SEPARATOR.'onyx-runtime-1.2.3-runtime-cpu.zip', 'cpu');
+        createZipArtifact($distPath.DIRECTORY_SEPARATOR.'fallback.zip', 'base');
+
+        $port = reserveFreePort();
+        $serverProcess = startPhpServer($distPath, $port);
+
+        waitForServerReady("http://127.0.0.1:$port/onyx-runtime-1.2.3-runtime-cpu.zip");
+        waitForServerReady("http://127.0.0.1:$port/fallback.zip");
+
+        $template = "http://127.0.0.1:$port/onyx-runtime-{version}-runtime-{runtime}.zip";
+        $fallbackUrl = "http://127.0.0.1:$port/fallback.zip";
+        $appComposerJson = [
+            'name' => 'integration/test-app-default-fallback',
+            'type' => 'project',
+            'require' => [
+                'codewithkyrian/platform-package-installer' => '2.0.0',
+                'org/onyx-runtime' => '1.2.3',
+            ],
+            'repositories' => [
+                ['packagist.org' => false],
+                [
+                    'type' => 'path',
+                    'url' => $pluginCopyPath,
+                    'options' => ['symlink' => false],
+                ],
+                [
+                    'type' => 'package',
+                    'package' => [
+                        'name' => 'org/onyx-runtime',
+                        'version' => '1.2.3',
+                        'type' => 'platform-package',
+                        'dist' => [
+                            'url' => $fallbackUrl,
+                            'type' => 'zip',
+                        ],
+                        'extra' => [
+                            'artifacts' => [
+                                'urls' => [
+                                    'all' => $template,
+                                ],
+                                'vars' => [
+                                    'runtime' => 'cpu',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'extra' => [
+                'platform-packages' => [
+                    'org/onyx-runtime' => [
+                        'runtime' => 'gpu',
+                    ],
+                ],
+            ],
+            'config' => [
+                'allow-plugins' => [
+                    'codewithkyrian/platform-package-installer' => true,
+                ],
+                'secure-http' => false,
+            ],
+        ];
+
+        file_put_contents(
+            $appPath.DIRECTORY_SEPARATOR.'composer.json',
+            json_encode($appComposerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $composerBin = findComposerBinary($repoRoot);
+        $install = runCommand(
+            [PHP_BINARY, $composerBin, 'install', '--no-interaction', '--no-progress'],
+            $appPath,
+            [
+                'COMPOSER_CACHE_DIR' => $tmpRoot.DIRECTORY_SEPARATOR.'cache',
+                'COMPOSER_HOME' => $tmpRoot.DIRECTORY_SEPARATOR.'home',
+            ],
+            120
+        );
+
+        if ($install['exit_code'] !== 0) {
+            throw new RuntimeException(
+                "composer install failed\nSTDERR:\n".$install['stderr']."\nSTDOUT:\n".$install['stdout']
+            );
+        }
+
+        $marker = $appPath.DIRECTORY_SEPARATOR.'vendor/org/onyx-runtime/cuda-version.txt';
+        expect(file_exists($marker))->toBeTrue();
+        expect(trim((string) file_get_contents($marker)))->toBe('cpu');
+    } finally {
+        if (is_array($serverProcess)) {
+            stopProcess($serverProcess);
+        }
+
+        if (is_dir($tmpRoot)) {
+            removeDirectoryRecursive($tmpRoot);
+        }
+    }
+});
+
 it('falls back to base dist URL when a required artifact variable is missing', function () {
     if (!class_exists(ZipArchive::class)) {
         $this->markTestSkipped('ZipArchive extension is required for integration test.');


### PR DESCRIPTION
This PR updates artifact URL resolution to retry with package default variables when the override-resolved URL is invalid, unresolved, or unavailable. If the default-based URL resolves successfully, Composer installs from that URL; if it also fails, behavior falls back to the existing Composer dist/source path.

## Motivation and Context
Consumers can provide override variables that resolve to a non-existent artifact variant even when the package default variant exists and is valid for the same platform. Previously, that scenario could drop directly to base Composer fallback behavior. This change improves resilience by attempting a sensible in-plugin fallback first (defaults + `{version}`), so users are more likely to get a usable platform artifact without manual intervention.

## What's Changed
- Updated installer URL resolution flow to attempt primary candidate using defaults + app overrides + {version}.
- Added retry candidate using defaults only + {version} when an override-based resolution fails.
- Kept final fallback behavior unchanged when both candidates fail.
- Added explicit logging for override failure and default-variable fallback usage.
- Updated README placeholder behavior section to document the new retry flow.

## Breaking Changes
None.