### PR TITLE
Fix: Add backward compatibility for legacy platform-urls config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Then change your package type to `platform-package` in `composer.json`:
 
 All core behavior is configured in `composer.json` under `extra.artifacts`.
 
+Legacy `extra.platform-urls` is still supported for backward compatibility, but is deprecated.
+
 ### Format A: Simple (no custom variables)
 
 Use this when:

--- a/src/PlatformInstaller.php
+++ b/src/PlatformInstaller.php
@@ -32,9 +32,8 @@ class PlatformInstaller extends LibraryInstaller
 
     private function resolveDistUrl(PackageInterface $package): string|false
     {
-        $artifacts = $package->getExtra()['artifacts'] ?? [];
-        if (!is_array($artifacts)) {
-            $this->io->writeError("{$package->getName()}: Invalid extra.artifacts config (expected object)");
+        $artifacts = $this->resolveArtifactsConfig($package);
+        if ($artifacts === false) {
             return false;
         }
 
@@ -80,6 +79,42 @@ class PlatformInstaller extends LibraryInstaller
 
         $this->io->writeError("{$package->getName()}: No download URL found for current platform");
         return false;
+    }
+
+    /**
+     * Resolve artifact config from v2 and legacy keys.
+     *
+     * v2 preferred key: extra.artifacts
+     * legacy key:       extra.platform-urls
+     *
+     * @return array<string, mixed>|false
+     */
+    private function resolveArtifactsConfig(PackageInterface $package): array|false
+    {
+        $extra = $package->getExtra();
+
+        if (array_key_exists('artifacts', $extra)) {
+            $artifacts = $extra['artifacts'];
+            if (!is_array($artifacts)) {
+                $this->io->writeError("{$package->getName()}: Invalid extra.artifacts config (expected object)");
+                return false;
+            }
+
+            return $artifacts;
+        }
+
+        if (array_key_exists('platform-urls', $extra)) {
+            $legacy = $extra['platform-urls'];
+            if (!is_array($legacy)) {
+                $this->io->writeError("{$package->getName()}: Invalid extra.platform-urls config (expected object)");
+                return false;
+            }
+
+            $this->io->writeError("{$package->getName()}: extra.platform-urls is deprecated. Please migrate to extra.artifacts.");
+            return $legacy;
+        }
+
+        return [];
     }
 
     /**

--- a/tests/Integration/ComposerInstallTest.php
+++ b/tests/Integration/ComposerInstallTest.php
@@ -463,6 +463,114 @@ it('installs platform package from simple artifacts format without vars', functi
     }
 });
 
+it('supports legacy extra.platform-urls configuration', function () {
+    if (!class_exists(ZipArchive::class)) {
+        $this->markTestSkipped('ZipArchive extension is required for integration test.');
+    }
+
+    $repoRoot = realpath(__DIR__.'/../../');
+    expect($repoRoot)->not->toBeFalse();
+    $repoRoot = (string) $repoRoot;
+
+    $tmpRoot = sys_get_temp_dir().DIRECTORY_SEPARATOR.'platform-package-installer-int-'.uniqid();
+    $pluginCopyPath = $tmpRoot.DIRECTORY_SEPARATOR.'plugin-under-test';
+    $distPath = $tmpRoot.DIRECTORY_SEPARATOR.'dist';
+    $appPath = $tmpRoot.DIRECTORY_SEPARATOR.'app';
+
+    mkdir($tmpRoot, 0777, true);
+    mkdir($distPath, 0777, true);
+    mkdir($appPath, 0777, true);
+
+    $serverProcess = null;
+    try {
+        copyPluginForPathRepository($repoRoot, $pluginCopyPath);
+        relaxPluginDependenciesForIntegration($pluginCopyPath, '2.0.0');
+
+        createZipArtifact($distPath.DIRECTORY_SEPARATOR.'onyx-runtime-1.2.3.zip', 'legacy');
+
+        $port = reserveFreePort();
+        $serverProcess = startPhpServer($distPath, $port);
+
+        waitForServerReady("http://127.0.0.1:$port/onyx-runtime-1.2.3.zip");
+
+        $legacyTemplate = "http://127.0.0.1:$port/onyx-runtime-{version}.zip";
+
+        $appComposerJson = [
+            'name' => 'integration/test-app-legacy-platform-urls',
+            'type' => 'project',
+            'require' => [
+                'codewithkyrian/platform-package-installer' => '2.0.0',
+                'org/onyx-runtime' => '1.2.3',
+            ],
+            'repositories' => [
+                ['packagist.org' => false],
+                [
+                    'type' => 'path',
+                    'url' => $pluginCopyPath,
+                    'options' => ['symlink' => false],
+                ],
+                [
+                    'type' => 'package',
+                    'package' => [
+                        'name' => 'org/onyx-runtime',
+                        'version' => '1.2.3',
+                        'type' => 'platform-package',
+                        'dist' => [
+                            'url' => "http://127.0.0.1:$port/should-not-be-used.zip",
+                            'type' => 'zip',
+                        ],
+                        'extra' => [
+                            'platform-urls' => [
+                                'all' => $legacyTemplate,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'config' => [
+                'allow-plugins' => [
+                    'codewithkyrian/platform-package-installer' => true,
+                ],
+                'secure-http' => false,
+            ],
+        ];
+
+        file_put_contents(
+            $appPath.DIRECTORY_SEPARATOR.'composer.json',
+            json_encode($appComposerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $composerBin = findComposerBinary($repoRoot);
+        $install = runCommand(
+            [PHP_BINARY, $composerBin, 'install', '--no-interaction', '--no-progress'],
+            $appPath,
+            [
+                'COMPOSER_CACHE_DIR' => $tmpRoot.DIRECTORY_SEPARATOR.'cache',
+                'COMPOSER_HOME' => $tmpRoot.DIRECTORY_SEPARATOR.'home',
+            ],
+            120
+        );
+
+        if ($install['exit_code'] !== 0) {
+            throw new RuntimeException(
+                "composer install failed\nSTDERR:\n".$install['stderr']."\nSTDOUT:\n".$install['stdout']
+            );
+        }
+
+        $marker = $appPath.DIRECTORY_SEPARATOR.'vendor/org/onyx-runtime/cuda-version.txt';
+        expect(file_exists($marker))->toBeTrue();
+        expect(trim((string) file_get_contents($marker)))->toBe('legacy');
+    } finally {
+        if (is_array($serverProcess)) {
+            stopProcess($serverProcess);
+        }
+
+        if (is_dir($tmpRoot)) {
+            removeDirectoryRecursive($tmpRoot);
+        }
+    }
+});
+
 /**
  * @return array{process: resource, stdout: resource, stderr: resource}
  */


### PR DESCRIPTION
This PR restores backward compatibility for packages still using the legacy `extra.platform-urls` key while keeping `extra.artifacts` as the preferred configuration. It routes both config styles through the same resolution flow, adds a deprecation notice for the legacy key, and includes integration coverage to ensure legacy installs continue to work correctly.

## Motivation and Context
After introducing the v2 artifacts model, existing packages using `platform-urls` could break during migration windows where maintainers need to support both old and new plugin versions. This PR ensures a smooth transition by accepting legacy configuration without changing current v2 behavior, so package authors can safely depend on `^1.1 || ^2.0` style compatibility while planning gradual config migration.

## Breaking Changes
None.